### PR TITLE
Upgrade to  3.5.0

### DIFF
--- a/bndrun/pom.xml
+++ b/bndrun/pom.xml
@@ -17,7 +17,7 @@
 			<plugin>
 				<groupId>biz.aQute.bnd</groupId>
 				<artifactId>bnd-export-maven-plugin</artifactId>
-				<version>3.4.0-SNAPSHOT</version>
+				<version>3.5.0</version>
 				<configuration>
 					<resolve>true</resolve>
 					<bndruns>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -20,7 +20,7 @@
 			<plugin>
 				<groupId>biz.aQute.bnd</groupId>
 				<artifactId>bnd-testing-maven-plugin</artifactId>
-				<version>3.4.0-SNAPSHOT</version>
+				<version>3.5.0</version>
 				<configuration>
 					<resolve>true</resolve>
 					<bndruns>


### PR DESCRIPTION
Fix for https://github.com/osgi/osgi.enroute.examples.eval/issues/5

* Update to bnd-export-maven-plugin 3.5.0
* Update to bnd-testing-maven-plugin 3.5.0